### PR TITLE
Use YAML instead of JSON to output YAML

### DIFF
--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -175,7 +175,7 @@ EOF
 # Integrations
 <% p("dd.integrations", {}).each do |integration, config| %>
 cat <<'YAML' > "${CONFD_DIR}/<%= integration %>.yaml"
-<%= JSON.dump(config) %>
+<%= YAML.dump(config) %>
 YAML
 
 <% end %>


### PR DESCRIPTION
We tried using the integrations to add a Memcached configuration. Using JSON.dump did not output the configuration correctly. However, using YAML.dump did render the config properly.

For reference, here's an example runtime-config.yml that we used:
```yaml
    dd:
      use_dogstatsd: yes
      api_key: <<redacted>>
      integrations:
        mcache:
          init_config: ''
          instances:
          - url: localhost
```